### PR TITLE
第4章3節 微分のはじめ

### DIFF
--- a/ch04/mini_batch.py
+++ b/ch04/mini_batch.py
@@ -9,3 +9,21 @@ batch_mask = np.random.choice(x_train.shape[0], 10)
 print(x_train.shape)
 print(t_train.shape)
 print(batch_mask)
+
+def cross_entropy_error(y, t):
+    if y.ndim == 1:
+        t = t.reshape(1, t.size)
+        y = y.reshape(1, y.size)
+
+    batch_size = y.shape[0]
+    return -np.sum(t*np.log(y + 1e-7)) / batch_size
+
+y = np.array([
+    [0.1, 0.05, 0.6, 0.0, 0.05, 0.1, 0.0, 0.1, 0.0, 0.0],
+    [0.1, 0.05, 0.6, 0.0, 0.05, 0.1, 0.0, 0.7, 0.0, 0.0],
+    [0.1, 0.05, 0.6, 0.0, 0.05, 0.1, 0.0, 0.1, 0.0, 0.0],
+    [0.1, 0.05, 0.6, 0.0, 0.05, 0.1, 0.0, 0.1, 0.0, 0.0],
+    [0.1, 0.05, 0.6, 0.0, 0.05, 0.1, 0.0, 0.1, 0.0, 0.0]])
+batch = np.arange(5)
+"""one-hot だと 0/1 だから、正解ラベル以外は掛けた値が0なので、正解ラベルだけ抽出すればよい"""
+t = np.array([2,7,0,9,4])

--- a/ch04/numerical_diff.py
+++ b/ch04/numerical_diff.py
@@ -1,0 +1,16 @@
+def numerical_diff(f, x):
+    h = 1e-4
+    return (f(x+h) - f(x-h)) / (2*h)
+
+def function1(x):
+    return 0.01*x**2 + 0.1*x
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+x = np.arange(0.0, 20.0, 0.1)
+y = function1(x)
+plt.xlabel("x")
+plt.ylabel("f(x)")
+plt.plot(x, y)
+plt.show()


### PR DESCRIPTION
今日のおすすめポイント
---

なぜ損失関数を設定するのか？

認識精度を指標にしては行けない。
認識精度はほとんどの場所で微分の結果が0となる。
パラメーターを変化させた時、連続して結果が変わらず、不連続に変化する。
損失関数を指標とした場合は、連続的に変化し、必ず微分の結果が正負どちらかの値になる。
